### PR TITLE
Fix Set::remove not working as expected

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,7 @@ mod interval;
 pub use interval::Interval;
 
 pub mod staff;
-pub use staff::{Key, Staff};
+pub use crate::staff::{Key, Staff};
 
 mod natural;
 pub use natural::Natural;

--- a/src/set.rs
+++ b/src/set.rs
@@ -69,7 +69,7 @@ where
     }
 
     pub fn remove(&mut self, item: T) {
-        self.bits = self.bits | !(U::one() << item.into() as usize);
+        self.bits = self.bits & !(U::one() << item.into() as usize);
     }
 
     pub fn contains(&self, item: T) -> bool {
@@ -118,5 +118,24 @@ where
 
     fn next(&mut self) -> Option<Self::Item> {
         self.pop_bit().map(Into::into)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Set;
+
+    #[test]
+    fn push_and_remove_from_set() {
+        let initial = [0, 2];
+        let mut set: Set<u8, u8> = Set::from_iter(initial.into_iter());
+
+        set.push(1);
+        assert!(set.contains(1));
+        set.remove(1);
+        assert!(!set.contains(1));
+
+        assert!(set.contains(0));
+        assert!(set.contains(2));
     }
 }


### PR DESCRIPTION
Set::remove() was not actually removing the entry due to the `or` instead of `and` bit operation.

Additionally: in lib.rs refer explicitly to crate::staff, otherwise I'm getting some ambiguous reference?