### PR TITLE
Add serde support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,8 @@ description = "Music theory library with midi, notes, chords, scales, and more"
 repository = "https://github.com/matthunz/staff"
 
 [features]
-cli = ["anyhow", "clap"]
+cli = ["anyhow", "clap", "serde"]
+serde = ["dep:serde"]
 
 [lib]
 name = "staff"
@@ -23,5 +24,10 @@ thiserror = "1.0"
 
 [dependencies.clap]
 version = "3.2.16"
+features = ["derive"]
+optional = true
+
+[dependencies.serde]
+version = "1.0"
 features = ["derive"]
 optional = true

--- a/src/chord/builder.rs
+++ b/src/chord/builder.rs
@@ -1,6 +1,7 @@
 use crate::{set::IntervalSet, Chord, Interval, Pitch};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Builder {
     pub bass: Option<Pitch>,
     pub is_inversion: bool,

--- a/src/chord/mod.rs
+++ b/src/chord/mod.rs
@@ -11,6 +11,7 @@ mod iter;
 pub use iter::{Intervals, Iter};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Chord {
     root: Pitch,
     builder: Builder,

--- a/src/interval.rs
+++ b/src/interval.rs
@@ -2,6 +2,7 @@ use core::ops::Add;
 
 /// Music interval in semitones.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Interval {
     semitones: u8,
 }

--- a/src/midi/midi_set.rs
+++ b/src/midi/midi_set.rs
@@ -2,6 +2,7 @@ use super::MidiNote;
 use crate::set::Set;
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct MidiSet {
     low: Set<MidiNote, u64>,
     high: Set<MidiNote, u64>,

--- a/src/midi/mod.rs
+++ b/src/midi/mod.rs
@@ -12,6 +12,7 @@ pub use midi_set::MidiSet;
 
 /// MIDI note represented as a byte.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct MidiNote(u8);
 
 impl MidiNote {

--- a/src/midi/octave.rs
+++ b/src/midi/octave.rs
@@ -4,6 +4,7 @@ use core::fmt;
 
 /// A note's octave in MIDI.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Octave(i8);
 
 impl Octave {

--- a/src/natural.rs
+++ b/src/natural.rs
@@ -3,6 +3,7 @@ use core::{fmt, ops::Add, str::FromStr};
 /// A natural pitch
 #[repr(u8)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Natural {
     A,
     B,

--- a/src/note.rs
+++ b/src/note.rs
@@ -5,6 +5,7 @@ use core::{
 };
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Accidental {
     Natural,
     Flat,
@@ -26,6 +27,7 @@ impl fmt::Display for Accidental {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Note {
     pub natural: Natural,
     pub accidental: Accidental,

--- a/src/pitch.rs
+++ b/src/pitch.rs
@@ -6,6 +6,7 @@ use core::{fmt, mem};
 /// Pitch class that can be found on the chromatic scale.
 #[repr(u8)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Pitch {
     C,
     CSharp,

--- a/src/scale/diatonic.rs
+++ b/src/scale/diatonic.rs
@@ -92,6 +92,7 @@ where
 }
 
 #[derive(Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Diatonic<T: Degree, U> {
     pub state: T::State,
     pub intervals: U,

--- a/src/scale/mod.rs
+++ b/src/scale/mod.rs
@@ -10,6 +10,7 @@ pub use intervals::ScaleIntervals;
 mod diatonic;
 pub use diatonic::{Diatonic, DiatonicScale};
 
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Scale<T, U> {
     root: T,
     intervals: U,

--- a/src/set.rs
+++ b/src/set.rs
@@ -16,6 +16,7 @@ impl IntervalSet {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Set<T, U> {
     pub bits: U,
     _marker: PhantomData<T>,

--- a/src/staff/key.rs
+++ b/src/staff/key.rs
@@ -3,6 +3,7 @@ use core::fmt::{self, Write};
 
 /// A key signature represented as the total number of sharps or flats.
 #[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Key {
     sharps: u8,
 }


### PR DESCRIPTION
This PR adds support for serialization/deserialization for the `serde` crate.

I'm not fond of this kind of change that goes everywhere in libraries, so I'd understand that it would not be merged, but without support from the source, serde is really hard to use.

The dependency on serde is conditioned by the `serde` feature, so it is not intrusive in the general builds. I've mostly blindly applied it for every public struct and enum except ones that are would obviously be useless (iterators, midi messages).