### PR TITLE
Serde support: remove automatic enablement for cli

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ description = "Music theory library with midi, notes, chords, scales, and more"
 repository = "https://github.com/matthunz/staff"
 
 [features]
-cli = ["anyhow", "clap", "serde"]
+cli = ["anyhow", "clap"]
 serde = ["dep:serde"]
 
 [lib]


### PR DESCRIPTION
I had just realized that I mistakenly enabled the feature for the "cli", but you were so fast to merge the PR :D