### PR TITLE
Added church modes and note constants

### DIFF
--- a/src/note.rs
+++ b/src/note.rs
@@ -55,26 +55,34 @@ pub struct Note {
 }
 
 impl Note {
-    pub fn new(natural: Natural, accidental: Accidental) -> Self {
+    pub const C: Self = Self::new(Natural::C, Accidental::Natural);
+    pub const D: Self = Self::new(Natural::D, Accidental::Natural);
+    pub const E: Self = Self::new(Natural::E, Accidental::Natural);
+    pub const F: Self = Self::new(Natural::F, Accidental::Natural);
+    pub const G: Self = Self::new(Natural::G, Accidental::Natural);
+    pub const A: Self = Self::new(Natural::A, Accidental::Natural);
+    pub const B: Self = Self::new(Natural::B, Accidental::Natural);
+
+    pub const fn new(natural: Natural, accidental: Accidental) -> Self {
         Self {
             natural,
             accidental,
         }
     }
 
-    pub fn flat(natural: Natural) -> Self {
+    pub const fn flat(natural: Natural) -> Self {
         Self::new(natural, Accidental::Flat)
     }
 
-    pub fn double_flat(natural: Natural) -> Self {
+    pub const fn double_flat(natural: Natural) -> Self {
         Self::new(natural, Accidental::DoubleFlat)
     }
 
-    pub fn sharp(natural: Natural) -> Self {
+    pub const fn sharp(natural: Natural) -> Self {
         Self::new(natural, Accidental::Sharp)
     }
 
-    pub fn double_sharp(natural: Natural) -> Self {
+    pub const fn double_sharp(natural: Natural) -> Self {
         Self::new(natural, Accidental::DoubleSharp)
     }
 }

--- a/src/scale/diatonic.rs
+++ b/src/scale/diatonic.rs
@@ -86,8 +86,32 @@ where
         Self::diatonic(root, ScaleIntervals::melodic_minor())
     }
 
+    pub fn ionian(root: T) -> Self {
+        Self::major(root)
+    }
+
     pub fn dorian(root: T) -> Self {
         Self::diatonic(root, ScaleIntervals::dorian())
+    }
+
+    pub fn phrygian(root: T) -> Self {
+        Self::diatonic(root, ScaleIntervals::phrygian())
+    }
+
+    pub fn lydian(root: T) -> Self {
+        Self::diatonic(root, ScaleIntervals::lydian())
+    }
+
+    pub fn mixolydian(root: T) -> Self {
+        Self::diatonic(root, ScaleIntervals::mixolydian())
+    }
+
+    pub fn aeolian(root: T) -> Self {
+        Self::natural_minor(root)
+    }
+
+    pub fn locrian(root: T) -> Self {
+        Self::diatonic(root, ScaleIntervals::locrian())
     }
 }
 

--- a/src/scale/intervals.rs
+++ b/src/scale/intervals.rs
@@ -73,4 +73,52 @@ impl ScaleIntervals {
             Interval::MINOR_SEVENTH,
         ])
     }
+
+    pub fn phrygian() -> Self {
+        Self::from_iter([
+            Interval::UNISON,
+            Interval::MINOR_SECOND,
+            Interval::MINOR_THIRD,
+            Interval::PERFECT_FOURTH,
+            Interval::PERFECT_FIFTH,
+            Interval::MINOR_SIXTH,
+            Interval::MINOR_SEVENTH,
+        ])
+    }
+
+    pub fn lydian() -> Self {
+        Self::from_iter([
+            Interval::UNISON,
+            Interval::MAJOR_SECOND,
+            Interval::MAJOR_THIRD,
+            Interval::TRITONE,
+            Interval::PERFECT_FIFTH,
+            Interval::MAJOR_SIXTH,
+            Interval::MAJOR_SEVENTH,
+        ])
+    }
+
+    pub fn mixolydian() -> Self {
+        Self::from_iter([
+            Interval::UNISON,
+            Interval::MAJOR_SECOND,
+            Interval::MAJOR_THIRD,
+            Interval::PERFECT_FOURTH,
+            Interval::PERFECT_FIFTH,
+            Interval::MAJOR_SIXTH,
+            Interval::MINOR_SEVENTH,
+        ])
+    }
+
+    pub fn locrian() -> Self {
+        Self::from_iter([
+            Interval::UNISON,
+            Interval::MINOR_SECOND,
+            Interval::MINOR_THIRD,
+            Interval::PERFECT_FOURTH,
+            Interval::TRITONE,
+            Interval::MINOR_SIXTH,
+            Interval::MINOR_SEVENTH,
+        ])
+    }
 }

--- a/src/scale/mod.rs
+++ b/src/scale/mod.rs
@@ -117,4 +117,34 @@ mod tests {
             Note::sharp(Natural::B),
         ]))
     }
+
+    #[test]
+    fn test_c_locrian() {
+        let scale = Scale::locrian(Note::from(Natural::C));
+
+        assert!(scale.eq([
+            Note::from(Natural::C),
+            Note::flat(Natural::D),
+            Note::flat(Natural::E),
+            Note::from(Natural::F),
+            Note::flat(Natural::G),
+            Note::flat(Natural::A),
+            Note::flat(Natural::B),
+        ]));
+    }
+
+    #[test]
+    fn test_c_lydian() {
+        let scale = Scale::lydian(Note::from(Natural::C));
+
+        assert!(scale.eq([
+            Note::C,
+            Note::D,
+            Note::E,
+            Note::sharp(Natural::F),
+            Note::G,
+            Note::A,
+            Note::B,
+        ]));
+    }
 }


### PR DESCRIPTION
Just added the rest of the diatonic scale modes, as well as constructors for scales. Also added associated constants for all the natural notes like `Note::C` because I think the ergonomics of always typing `Note::from(Natural::C)` leave something to be desired. I changed many of the functions to be `const` since I needed at least `new()` to be const to make the constants, and for the rest there wasn't much reason not to. `From` can't be const at the moment unfortunately, but I figured this was a fine start.

After implementing the constants, I also had the idea of making functions `flatten()` and `sharpen()` that take a `&self` and then return a changed version like so: `Note::C.sharpen()`. This could even work for notes that already have accidentals. My original thought was to change `flat()` and `sharp()` but that would both be a breaking change and not entirely clear what would happen when used multiple times. I thought that was a bit out of the scope of a pretty routine PR, but I'd be happy to implement those as well.