### PR TITLE
Add&fix Interval::Display, fix MidiSet offest, check MidiNote range

### DIFF
--- a/src/chord/mod.rs
+++ b/src/chord/mod.rs
@@ -119,6 +119,10 @@ impl Chord {
         Self::minor(root).with_interval(Interval::MINOR_SEVENTH)
     }
 
+    pub fn minor_ninth(self) -> Self {
+        self.with_interval(Interval::MINOR_NINTH)
+    }
+
     pub fn major_ninth(self) -> Self {
         self.with_interval(Interval::MAJOR_NINTH)
     }

--- a/src/interval.rs
+++ b/src/interval.rs
@@ -33,6 +33,7 @@ impl Interval {
 
     pub const OCTAVE: Self = Self::new(12);
 
+    pub const MINOR_NINTH: Self = Self::new(13);
     pub const MAJOR_NINTH: Self = Self::new(14);
 
     pub const MINOR_ELEVENTH: Self = Self::new(16);
@@ -82,20 +83,22 @@ impl fmt::Display for Interval {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             Interval::UNISON => f.write_char('1'),
-            Interval::MINOR_SECOND => f.write_str("maj2"),
+            Interval::MINOR_SECOND => f.write_str("b2"),
             Interval::MAJOR_SECOND => f.write_char('2'),
             Interval::MINOR_THIRD => f.write_str("b3"),
             Interval::MAJOR_THIRD => f.write_char('3'),
             Interval::PERFECT_FOURTH => f.write_char('4'),
+            Interval::TRITONE => f.write_str("b5"),
             Interval::PERFECT_FIFTH => f.write_char('5'),
             Interval::MINOR_SIXTH => f.write_str("b6"),
             Interval::MAJOR_SIXTH => f.write_char('6'),
             Interval::MINOR_SEVENTH => f.write_str("m7"),
             Interval::MAJOR_SEVENTH => f.write_str("maj7"),
+            Interval::MINOR_NINTH => f.write_str("b9"),
             Interval::MAJOR_NINTH => f.write_char('9'),
             Interval::MINOR_ELEVENTH => f.write_str("11"),
             Interval::MAJOR_ELEVENTH => f.write_str("maj11"),
-            Interval::MINOR_THIRTEENTH => f.write_str("11"),
+            Interval::MINOR_THIRTEENTH => f.write_str("13"),
             Interval::MAJOR_THIRTEENTH => f.write_str("maj13"),
             i => panic!("{:?}", i),
         }

--- a/src/interval.rs
+++ b/src/interval.rs
@@ -35,12 +35,15 @@ impl Interval {
 
     pub const MINOR_NINTH: Self = Self::new(13);
     pub const MAJOR_NINTH: Self = Self::new(14);
+    pub const AUG_NINTH: Self = Self::new(15);
 
     pub const MINOR_ELEVENTH: Self = Self::new(16);
     pub const MAJOR_ELEVENTH: Self = Self::new(17);
+    pub const AUG_ELEVENTH: Self = Self::new(18);
 
     pub const MINOR_THIRTEENTH: Self = Self::new(20);
     pub const MAJOR_THIRTEENTH: Self = Self::new(21);
+    pub const AUG_THIRTEENTH: Self = Self::new(22);
 
     pub const fn new(semitones: u8) -> Self {
         Self { semitones }
@@ -94,12 +97,16 @@ impl fmt::Display for Interval {
             Interval::MAJOR_SIXTH => f.write_char('6'),
             Interval::MINOR_SEVENTH => f.write_str("m7"),
             Interval::MAJOR_SEVENTH => f.write_str("maj7"),
+            Interval::OCTAVE => f.write_char('8'),
             Interval::MINOR_NINTH => f.write_str("b9"),
             Interval::MAJOR_NINTH => f.write_char('9'),
-            Interval::MINOR_ELEVENTH => f.write_str("11"),
-            Interval::MAJOR_ELEVENTH => f.write_str("maj11"),
-            Interval::MINOR_THIRTEENTH => f.write_str("13"),
-            Interval::MAJOR_THIRTEENTH => f.write_str("maj13"),
+            Interval::AUG_NINTH => f.write_str("#9"),
+            Interval::MINOR_ELEVENTH => f.write_str("b11"),
+            Interval::MAJOR_ELEVENTH => f.write_str("11"),
+            Interval::AUG_ELEVENTH => f.write_str("#11"),
+            Interval::MINOR_THIRTEENTH => f.write_str("b13"),
+            Interval::MAJOR_THIRTEENTH => f.write_str("13"),
+            Interval::AUG_THIRTEENTH => f.write_str("#13"),
             i => panic!("{:?}", i),
         }
     }

--- a/src/midi/midi_set.rs
+++ b/src/midi/midi_set.rs
@@ -13,6 +13,34 @@ impl MidiSet {
         with_midi(self.low, self.high, midi, |set, midi| set.contains(midi))
     }
 
+    pub fn split(self, midi: MidiNote) -> (Self, Self) {
+        if midi <= MidiNote::from_byte(63) {
+            let (lower_low, upper_low) = self.low.split(midi);
+            (
+                MidiSet {
+                    low: lower_low,
+                    ..Default::default()
+                },
+                MidiSet {
+                    low: upper_low,
+                    high: self.high,
+                },
+            )
+        } else {
+            let (lower_high, upper_high) = self.high.split(midi);
+            (
+                MidiSet {
+                    low: self.low,
+                    high: lower_high,
+                },
+                MidiSet {
+                    high: upper_high,
+                    ..Default::default()
+                },
+            )
+        }
+    }
+
     pub fn push(&mut self, midi: MidiNote) {
         self.inner(midi, |set, midi| set.push(midi))
     }
@@ -36,7 +64,7 @@ where
     if midi <= MidiNote::from_byte(63) {
         f(low, midi)
     } else {
-        let byte = midi.into_byte() - 63;
+        let byte = midi.into_byte() - 64;
         f(high, MidiNote::from(byte))
     }
 }
@@ -64,7 +92,7 @@ impl Iterator for MidiSet {
         self.low.next().or_else(|| {
             self.high
                 .next()
-                .map(|midi| MidiNote::from(midi.into_byte() + 63))
+                .map(|midi| MidiNote::from(midi.into_byte() + 64))
         })
     }
 }

--- a/src/midi/midi_set.rs
+++ b/src/midi/midi_set.rs
@@ -13,9 +13,9 @@ impl MidiSet {
         with_midi(self.low, self.high, midi, |set, midi| set.contains(midi))
     }
 
-    pub fn split(self, midi: MidiNote) -> (Self, Self) {
+    pub fn split(mut self, midi: MidiNote) -> (Self, Self) {
         if midi <= MidiNote::from_byte(63) {
-            let (lower_low, upper_low) = self.low.split(midi);
+            let (lower_low, upper_low) = self.inner(midi, |set, midi| set.split(midi));
             (
                 MidiSet {
                     low: lower_low,
@@ -27,7 +27,7 @@ impl MidiSet {
                 },
             )
         } else {
-            let (lower_high, upper_high) = self.high.split(midi);
+            let (lower_high, upper_high) = self.inner(midi, |set, midi| set.split(midi));
             (
                 MidiSet {
                     low: self.low,

--- a/src/midi/mod.rs
+++ b/src/midi/mod.rs
@@ -35,6 +35,7 @@ impl MidiNote {
 
     /// Create a new `MidiNote` from a byte.
     pub const fn from_byte(byte: u8) -> Self {
+        assert!(byte <= 127, "byte>127 isn't a valid midi note");
         Self(byte)
     }
 

--- a/src/set.rs
+++ b/src/set.rs
@@ -95,10 +95,10 @@ where
     }
 
     pub fn split(self, item: T) -> (Self, Self) {
-        let byte = item.into() as usize;
+        let bit = item.into() as usize;
         (
-            Self::new(self.bits & ((U::one() << byte) - U::one())),
-            Self::new((self.bits >> byte) << byte),
+            Self::new(self.bits & ((U::one() << bit) - U::one())),
+            Self::new((self.bits >> bit) << bit),
         )
     }
 }


### PR DESCRIPTION
A few minimal changes : 
- the offset in `MidiSet` just didn't allow to store midi note 127 (the only victim there)
- got a panic on tritone & b9 Display so added those
- thought that having split on `Midiset` would be nice